### PR TITLE
Enable .htaccess file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
     mv /wordpress /app && \
     rm -rf /var/lib/apt/lists/*
 
+RUN sed -i "s/AllowOverride None/AllowOverride All/g" /etc/apache2/apache2.conf
 ADD wp-config.php /app/wp-config.php
 ADD run.sh /run.sh
 RUN chmod +x /*.sh


### PR DESCRIPTION
Change the AllowOverride setting apache configuration to allow for
.htaccess files, and by extension beautiful URLs in Wordpress.